### PR TITLE
enable HiddenHttpMethodFilter to allow Delete, Patch and Put mappings form HTTP POST requests

### DIFF
--- a/src/main/java/bg/softuni/tabula/announcement/AnnouncementController.java
+++ b/src/main/java/bg/softuni/tabula/announcement/AnnouncementController.java
@@ -53,11 +53,8 @@ public class AnnouncementController {
     return "redirect:/announcements";
   }
 
-  @PostMapping("/delete")
+  @DeleteMapping("/delete")
   public String delete(@ModelAttribute(name="deleteId") Long announcementId) {
-
-    // In the REST world this would be a delete mapping but here this is not the case
-    // Have a look at: https://softwareengineering.stackexchange.com/questions/114156/why-are-there-are-no-put-and-delete-methods-on-html-forms
 
     announcementService.deleteAnnouncement(announcementId);
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,10 @@ spring:
             client-secret: senko
   thymeleaf:
     cache: false
+  mvc:
+    hiddenmethod:
+      filter:
+        enabled: true
 logging:
   level:
     org.springframework.web: DEBUG

--- a/src/main/resources/templates/announcement/delete.html
+++ b/src/main/resources/templates/announcement/delete.html
@@ -25,7 +25,7 @@
             <form
                 id="formDelete"
                 th:action="@{/announcements/delete}"
-                method="post">
+                th:method="delete">
               <input id="deleteId" name="deleteId" type="hidden" value=""/>
               <button id="btnDelete" type="submit" class="btn btn-primary">Delete</button>
            </form>


### PR DESCRIPTION

[HiddenHttpMethodFilter](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/filter/HiddenHttpMethodFilter.html):

> Filter that converts posted method parameters into HTTP methods, retrievable via HttpServletRequest.getMethod(). Since browsers currently only support GET and POST, a common technique - used by the Prototype library, for instance - is to use a normal POST with an additional hidden form field (_method) to pass the "real" HTTP method along. This filter reads that parameter and changes the HttpServletRequestWrapper.getMethod() return value accordingly. Only "PUT", "DELETE" and "PATCH" HTTP methods are allowed.

Thymeleaf adds this hidden input automatically when **th:action** is set to "delete", "patch" or "put".

HiddenHttpMethodFilter is disabled by default and the bean could either be created manually (useful for customizations) or enabled by a [property](https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-application-properties.html) in application.yaml / application.properties:

spring.mvc.hiddenmethod.filter.enabled=true

