### PR TITLE
disable Spring Boot's Open Session In View

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+    open-in-view: false
   security:
     oauth2:
       client:


### PR DESCRIPTION
Spring Boot's Open Session In View (OSIV) is enabled by default, but it is considered as anti-pattern by many and is highly advisable to be disabled.

https://vladmihalcea.com/the-open-session-in-view-anti-pattern/
https://www.changchao.me/?p=782
https://www.baeldung.com/spring-open-session-in-view