### PR TITLE
update MySQL docker image from 5.7 to 8 (8.0.20 at the moment)

### DIFF
--- a/local/docker-compose-local.yml
+++ b/local/docker-compose-local.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   db:
-    image: mysql:5.7
+    image: mysql:8
     ports:
       - "3306:3306"
     environment:


### PR DESCRIPTION
Match used MySQL dependency version and also fix issues with UTF-8 support (exception on persisting cyrillic letters)