### PR TITLE
use WebJars for managing of client-side web libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,10 @@ ext {
 	mysqlConnectorVersion = "8.0.20"
 	mapStructVersion = "1.3.1.Final"
 	lombokVersion = "1.18.12"
+	webjarsLocatorVersion = '0.40'
+	jQueryVersion = '3.5.1'
+	popperJsVersion = '2.0.2'
+	bootstrapVersion = '4.5.0'
 }
 
 dependencies {
@@ -38,6 +42,11 @@ dependencies {
 	implementation 'org.springframework.security:spring-security-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.liquibase:liquibase-core'
+
+	compileOnly "org.webjars:webjars-locator:${webjarsLocatorVersion}"
+	compileOnly "org.webjars:jquery:${jQueryVersion}"
+	compileOnly "org.webjars:popper.js:${popperJsVersion}"
+	compileOnly "org.webjars:bootstrap:${bootstrapVersion}"
 
 	compileOnly "org.mapstruct:mapstruct:${mapStructVersion}"
 	compileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/src/main/resources/templates/fragments/bootstrap-js.html
+++ b/src/main/resources/templates/fragments/bootstrap-js.html
@@ -3,19 +3,8 @@
 <body>
 
 <div th:fragment="bootstrap-js">
-  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-          integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
-          crossorigin="anonymous">
-  </script>
-  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
-          integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
-          crossorigin="anonymous">
-  </script>
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
-          integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6"
-          crossorigin="anonymous">
-
-  </script>
+  <script th:src="@{/webjars/popper.js/umd/popper.min.js}" type="text/javascript"></script>
+  <script th:src="@{/webjars/bootstrap/js/bootstrap.bundle.min.js}" type="text/javascript"></script>
 </div>
 
 </body>

--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -6,23 +6,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
   <!-- Styles -->
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-  <link rel="stylesheet" th:href="@{/css/tabula.css}">
+  <link rel="stylesheet" th:href="@{/webjars/bootstrap/css/bootstrap.min.css}" type="text/css">
+  <link rel="stylesheet" th:href="@{/css/tabula.css}" type="text/css">
   <!-- EO: Styles -->
 
   <!-- Javascript -->
-  <script
-      type="text/javascript"
-      src="https://code.jquery.com/jquery-3.5.0.min.js"
-      integrity="sha256-xNzN2a4ltkB44Mc/Jz3pT4iU1cmeR0FkXs4pru/JxaQ="
-      crossorigin="anonymous"></script>
+  <script th:src="@{/webjars/jquery/jquery.min.js}" type="text/javascript"></script>
 
-  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js" integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous"></script>
-
-  <script src="https://kit.fontawesome.com/bdb2495b74.js" crossorigin="anonymous"></script>
+  <script src="https://kit.fontawesome.com/bdb2495b74.js" type="text/javascript" crossorigin="anonymous"></script>
   <!-- EO: Javascript -->
-
 </head>
 <body>
 </body>

--- a/src/main/resources/templates/fragments/head.html
+++ b/src/main/resources/templates/fragments/head.html
@@ -8,7 +8,6 @@
   <!-- Styles -->
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" th:href="@{/css/tabula.css}">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tempusdominus-bootstrap-4/5.0.1/css/tempusdominus-bootstrap-4.min.css" />
   <!-- EO: Styles -->
 
   <!-- Javascript -->


### PR DESCRIPTION
- remove unused/incomplete Tempus Dominus CSS CDN
- fix multiple jQuery versions loaded at the same time (3.4.1 and 3.5.0)
- remove PopperJS and Bootstrap JS CDNs from <head> fragment
- replaced jQuery, PopperJS and Bootstrap CDNs with WebJars
- jQuery version: 3.5.1
- PopperJS version: 2.0.2
- Bootstrap version: 4.5.0
