### PR TITLE
enable static resources caching, compression and versioning

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,6 +25,18 @@ spring:
     hiddenmethod:
       filter:
         enabled: true
+  resources:
+    cache:
+      cachecontrol:
+        max-age: 30d
+    chain:
+      strategy:
+        content:
+          enabled: true
+          paths: /css/**
+server:
+  compression:
+    enabled: true
 logging:
   level:
     org.springframework.web: DEBUG


### PR DESCRIPTION
- cache duration set to 30 days
- files served from (/resources/static) /css/** are set to use ContentVersionStrategy for cache invalidation on file change:
        https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/servlet/resource/ContentVersionStrategy.html
- the above is not required for files served by WebJars, as those have lib version included in their URI
- files over 2KB (this is the default) in size will be compressed

NOTE: Compression doesn't work for resources under ContentVersionStrategy:
https://stackoverflow.com/q/60377766/7598851
https://github.com/spring-projects/spring-framework/issues/24898