### PR TITLE
add and configure IdeaModule to download sources and Javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.3.0.RELEASE'
 	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'
+	id 'idea'
 }
 
 group = 'bg.softuni'
@@ -10,6 +11,13 @@ version = '0.0.1-SNAPSHOT'
 java {
 	sourceCompatibility = JavaVersion.VERSION_11
 	targetCompatibility = JavaVersion.VERSION_11
+}
+
+idea {
+	module {
+		downloadJavadoc = true
+		downloadSources = true
+	}
 }
 
 repositories {


### PR DESCRIPTION
For Maven projects downloading of dependencies' sources and Javadoc is just one-click away,
but for Gradle it requires the IdeaModule and explicit configuration:

https://docs.gradle.org/current/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.html